### PR TITLE
feat: create grok deployment

### DIFF
--- a/grok/README.md
+++ b/grok/README.md
@@ -1,0 +1,11 @@
+# Grok on Akash Network
+
+Grok repository: https://github.com/xai-org/grok-1
+
+This deployment uses 4 CPU and 8 GPU (using H100 each). If you are trying to use 1 GPU would result to an error. Currently, this deployment requires `/dev/shm` to be enabled by the provider or this error will occur:
+
+`OSError: [Errno 28] No space left on device: './checkpoints/ckpt-0/tensor00000_000' -> '/dev/shm/tmp238nenvh'`
+
+Some modifications:
+- Uses jax[cuda12_pip]==0.4.23 instead of jax[cuda12_pip]==0.4.25
+- Models downloaded from huggingface instead of torrent for faster download

--- a/grok/deploy.yaml
+++ b/grok/deploy.yaml
@@ -1,0 +1,56 @@
+---
+version: "2.0"
+services:
+  app:
+    image: nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04
+    expose:
+      - port: 8080
+        as: 80
+        proto: tcp
+        to:
+          - global: true
+    command:
+      - bash
+      - "-c"
+    args:
+      - >-
+        apt-get update ; apt-get upgrade -y ;
+        apt-get install pip wget git -y;
+        pip install dm_haiku==0.0.12;
+        pip install jax[cuda12_pip]==0.4.23 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+        pip install numpy==1.26.4;
+        pip install sentencepiece==0.2.0;
+        pip install -U "huggingface_hub[cli]";
+        git clone https://github.com/xai-org/grok-1;
+        wget https://github.com/yudai/gotty/releases/download/v2.0.0-alpha.3/gotty_2.0.0-alpha.3_linux_amd64.tar.gz;
+        tar -zxvf gotty_2.0.0-alpha.3_linux_amd64.tar.gz ; chmod +x gotty ; rm -rf gotty_2.0.0-alpha.3_linux_amd64.tar.gz ; mv gotty /usr/local/bin/;
+        huggingface-cli download xai-org/grok-1 --repo-type model --include ckpt/tensor* --local-dir /grok-1/checkpoints --local-dir-use-symlinks False;
+        mv /grok-1/checkpoints/ckpt /grok-1/checkpoints/ckpt-0;
+        cd /grok-1 && gotty -w python3 ./run.py;
+        sleep infinity
+profiles:
+  compute:
+    app:
+      resources:
+        cpu:
+          units: 4
+        memory:
+          size: 15Gi
+        storage:
+          - size: 600Gi
+        gpu:
+          units: 8
+          attributes:
+            vendor:
+              nvidia:
+  placement:
+    akash:
+      pricing:
+        app:
+          denom: uakt
+          amount: 100000
+deployment:
+  app:
+    akash:
+      profile: app
+      count: 1


### PR DESCRIPTION
# Grok on Akash Network

Grok repository: https://github.com/xai-org/grok-1

This deployment uses 4 CPU and 8 GPU (using H100 each). If you are trying to use 1 GPU would result to an error. Currently, this deployment requires `/dev/shm` to be enabled by the provider or this error will occur:

`OSError: [Errno 28] No space left on device: './checkpoints/ckpt-0/tensor00000_000' -> '/dev/shm/tmp238nenvh'`
![error](https://github.com/yusufpraditya/awesome-akash/assets/47532266/823f0ba4-2dac-49fd-a3f4-b072fcad2739)


Some modifications:
- Uses jax[cuda12_pip]==0.4.23 instead of jax[cuda12_pip]==0.4.25
- Models downloaded from huggingface instead of torrent for faster download